### PR TITLE
TECH-1027: Bump parent to 8.2; remove portlet taglib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <parent>
     <groupId>org.jahia.modules</groupId>
     <artifactId>jahia-modules</artifactId>
-    <version>8.1.3.0</version>
+    <version>8.2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>dx-base-demo-components</artifactId>
   <version>2.5.0-SNAPSHOT</version>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1027

Bump to Jahia 8.2.0.0-SN and recompile to remove portlet taglibs package dependency

Note: merge only when core portlet taglib PR is merged: https://github.com/Jahia/jahia-private/pull/1708