### PR TITLE
QA-14452: Prevent XSS in social links using a validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <parent>
     <groupId>org.jahia.modules</groupId>
     <artifactId>jahia-modules</artifactId>
-    <version>8.2.0.0</version>
+    <version>8.2.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>dx-base-demo-components</artifactId>
   <version>3.1.0-SNAPSHOT</version>
@@ -82,6 +82,14 @@
       <url>https://devtools.jahia.com/nexus/content/groups/public</url>
     </repository>
   </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <parent>
     <groupId>org.jahia.modules</groupId>
     <artifactId>jahia-modules</artifactId>
-    <version>8.2.1.0-SNAPSHOT</version>
+    <version>8.2.0.0</version>
   </parent>
   <artifactId>dx-base-demo-components</artifactId>
   <version>3.1.0-SNAPSHOT</version>

--- a/src/main/java/org/jahia/modules/jahiademo/validation/NoJavaScriptLink.java
+++ b/src/main/java/org/jahia/modules/jahiademo/validation/NoJavaScriptLink.java
@@ -1,0 +1,48 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2025 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.jahiademo.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = NoJavaScriptLinkValidator.class)
+@Documented
+public @interface NoJavaScriptLink {
+
+    Class<?>[] groups() default {};
+
+    String message() default "{org.jahia.modules.jahiademo.validation.NoJavascriptLink.message}";
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/org/jahia/modules/jahiademo/validation/NoJavaScriptLinkValidator.java
+++ b/src/main/java/org/jahia/modules/jahiademo/validation/NoJavaScriptLinkValidator.java
@@ -1,0 +1,43 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2025 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.jahiademo.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+public class NoJavaScriptLinkValidator implements ConstraintValidator<NoJavaScriptLink, Object> {
+    private static final Pattern SAFE_URL_PATTERN = Pattern.compile("^(?!javascript:).*$", Pattern.CASE_INSENSITIVE);
+
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        if (value instanceof String) {
+            return SAFE_URL_PATTERN.matcher((String) value).matches();
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/jahia/modules/jahiademo/validation/SocialLinkValidator.java
+++ b/src/main/java/org/jahia/modules/jahiademo/validation/SocialLinkValidator.java
@@ -1,0 +1,61 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2025 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.jahiademo.validation;
+
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.decorator.validation.JCRNodeValidator;
+
+public class SocialLinkValidator implements JCRNodeValidator {
+    JCRNodeWrapper node;
+
+    public SocialLinkValidator(JCRNodeWrapper node) {
+        this.node = node;
+    }
+
+
+    @NoJavaScriptLink
+    public String getFacebook() {
+        return node.getPropertyAsString("facebook");
+    }
+
+    @NoJavaScriptLink
+    public String getGooglePlus() {
+        return node.getPropertyAsString("googlePlus");
+    }
+
+    @NoJavaScriptLink
+    public String getLinkedIn() {
+        return node.getPropertyAsString("linkedIn");
+    }
+
+    @NoJavaScriptLink
+    public String getTwitter() {
+        return node.getPropertyAsString("twitter");
+    }
+
+    @NoJavaScriptLink
+    public int getTest() {
+        return 123;
+    }
+}

--- a/src/main/java/org/jahia/modules/jahiademo/validation/SocialLinkValidatorDefinition.java
+++ b/src/main/java/org/jahia/modules/jahiademo/validation/SocialLinkValidatorDefinition.java
@@ -1,0 +1,40 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2025 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.jahiademo.validation;
+
+import org.jahia.services.content.decorator.validation.JCRNodeValidatorDefinition;
+import org.osgi.service.component.annotations.Component;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Component(service = JCRNodeValidatorDefinition.class)
+public class SocialLinkValidatorDefinition extends JCRNodeValidatorDefinition {
+
+    @Override
+    public Map<String, Class> getValidators() {
+        return Collections.singletonMap("jdmix:socialIcons", SocialLinkValidator.class);
+    }
+
+}

--- a/src/main/resources/resources/dx-base-demo-components.properties
+++ b/src/main/resources/resources/dx-base-demo-components.properties
@@ -212,3 +212,4 @@ jdnt_company.phone=Phone
 jdnt_company.thumbnail=Thumbnail
 jdnt_company.website=Website
 jdnt_companyNews=Related News
+org.jahia.modules.jahiademo.validation.NoJavascriptLink.message=The link must not start with 'javascript:'

--- a/src/test/java/org/jahia/modules/jahiademo/validation/NoJavaScriptLinkValidatorTest.java
+++ b/src/test/java/org/jahia/modules/jahiademo/validation/NoJavaScriptLinkValidatorTest.java
@@ -1,0 +1,59 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2025 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.jahiademo.validation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NoJavaScriptLinkValidatorTest {
+    NoJavaScriptLinkValidator validator = new NoJavaScriptLinkValidator();
+
+    @Test
+    public void GIVEN_null_object_WHEN_validate_THEN_is_valid() {
+        assertTrue(validator.isValid(null, null));
+    }
+
+    @Test
+    public void GIVEN_non_string_object_WHEN_validate_THEN_is_not_valid() {
+        assertFalse(validator.isValid(5, null));
+    }
+
+    @Test
+    public void GIVEN_safe_string_WHEN_validate_THEN_is_valid() {
+        assertTrue(validator.isValid("https://example.com", null));
+    }
+
+    @Test
+    public void GIVEN_unsafe_string_WHEN_validate_THEN_is_not_valid() {
+        assertFalse(validator.isValid("javascript:('alert XSS')", null));
+    }
+
+    @Test
+    public void GIVEN_unsafe_string_mixed_case_WHEN_validate_THEN_is_not_valid() {
+        assertFalse(validator.isValid("JavaScript:('alert XSS')", null));
+    }
+
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/QA-14452

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Prevent XSS vulnerabilities in social links (Twitter, Facebook, etc.) by creating a new constraint `@NoJavaScriptLink`, that ensures the social links contain safe URLs, i.e. that do not start with `javascript:`.
NB: The constraint `@NoJavaScriptLink` and its validator `NoJavaScriptLinkValidator` could eventually be moved to _Jahia core_ or to a dedicated _Validation bundle_ if we decide to group common validation helpers in one place.

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
