### PR TITLE
TECH-2055: Do not use <template:module> for HTML attributes

### DIFF
--- a/src/main/resources/jdmix_fileAttachment/html/fileAttachment.fileAttachment.jsp
+++ b/src/main/resources/jdmix_fileAttachment/html/fileAttachment.fileAttachment.jsp
@@ -23,7 +23,8 @@
 <jcr:nodeProperty node="${currentNode}" name="pdfVersion" var="pdfVersion"/>
 <c:if test="${not empty pdfVersion}">
     <template:module node="${pdfVersion.node}" view="hidden.name" editable="false" var="pdfName"/>
-    <template:module node="${pdfVersion.node}" view="hidden.contentURL" editable="false" var="pdfUrl"/>
+    <template:addCacheDependency node="${pdfVersion.node}"/>
+    <c:url var="pdfUrl" value="${pdfVersion.node.url}" context="/"/>
     <c:set var="label" value="${currentNode.properties.downloadTitle.string}"/>
     <c:if test="${empty label}">
         <c:set var="label"><fmt:message key="jdmix_fileAttachment.label"/></c:set>

--- a/src/main/resources/jdmix_internalLink/html/internalLink.parallaxLink.jsp
+++ b/src/main/resources/jdmix_internalLink/html/internalLink.parallaxLink.jsp
@@ -24,5 +24,6 @@
 <c:if test="${empty linkTitle}">
     <c:set var="linkTitle" value="${linkNode.displayableName}"/>
 </c:if>
-<a href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false" />" style="text-decoration: none;"
+<template:addCacheDependency node="${linkNode}"/>
+<a href="<c:url value="${linkNode.url}" context="/"/>" style="text-decoration: none;"
    class="btn-u btn-brd btn-brd-hover btn-u-light">${linkTitle}</a>

--- a/src/main/resources/jdmix_videoSlider/html/videoSlider.backgroundVideo.jsp
+++ b/src/main/resources/jdmix_videoSlider/html/videoSlider.backgroundVideo.jsp
@@ -24,12 +24,14 @@
 <video data-autopause="false" data-mute="true" data-loop="true" data-fill-mode="fill">
     <c:choose>
         <c:when test="${not empty mp4.node}">
-            <template:module path="${mp4.node.path}" view="hidden.contentURL" editable="false" var="mp4Url"/>
+            <template:addCacheDependency node="${mp4.node}"/>
+            <c:url var="mp4Url" value="${mp4.node.url}" context="/"/>
             <source src="${mp4Url}" type="video/mp4"/>
         </c:when>
         <c:when test="${not empty webm.node}">
-            <template:module path="${webm.node.path}" view="hidden.contentURL" editable="false" var="webmURL"/>
-            <source src="${webmURL}" type="video/webm"/>
+            <template:addCacheDependency node="${webm.node}"/>
+            <c:url var="webmUrl" value="${webm.node.url}" context="/"/>
+            <source src="${webmUrl}" type="video/webm"/>
         </c:when>
         <c:otherwise></c:otherwise>
     </c:choose>

--- a/src/main/resources/jdnt_carouselImg/html/carouselImg.jsp
+++ b/src/main/resources/jdnt_carouselImg/html/carouselImg.jsp
@@ -18,7 +18,8 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 <%-- get the caption --%>
 <c:set var="caption" value="${currentNode.properties['caption'].string}"/>
-<template:module path="${currentNode.properties.image.node.path}" view="hidden.contentURL" editable="false" var="imgURL"/>
+<template:addCacheDependency node="${currentNode.properties['image'].node}"/>
+<c:url var="imgURL" value="${currentNode.properties['image'].node.url}"  context="/"/>
 <img class="carouselImageFull" src="${imgURL}" alt="${caption}">
 <c:if test="${not empty caption}">
     <div class="carousel-caption">

--- a/src/main/resources/jdnt_carouselImg/html/carouselImg.owl.jsp
+++ b/src/main/resources/jdnt_carouselImg/html/carouselImg.owl.jsp
@@ -17,7 +17,8 @@
 <%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 <%-- get the url of the image to display --%>
-<template:module path="${currentNode.properties.image.node.path}" view="hidden.contentURL" editable="false" var="imgURL"/>
+<template:addCacheDependency node="${currentNode.properties.image.node}"/>
+<c:url var="imgURL" value="${currentNode.properties.image.node.url}" context="/" />
 
 <div class="owl-item owl-fix-width">
     <div class="item">

--- a/src/main/resources/jdnt_company/html/company.banner.jsp
+++ b/src/main/resources/jdnt_company/html/company.banner.jsp
@@ -33,8 +33,9 @@
     <div class="container">
         <c:choose>
             <c:when test="${not empty logo}">
-                <template:module path="${logo.node.path}" view="hidden.contentURL" editable="false" var="logoURL"/>
-                <img src="${logoURL}" class="company-banner-logo"/>
+                <template:addCacheDependency node="${logo.node}"/>
+                <c:url value="${url.files}${logo.node.path}" var="logoUrl"/>
+                <img src="${logoUrl}" class="company-banner-logo"/>
             </c:when>
             <c:otherwise>
                 <h1>${title.string}</h1>

--- a/src/main/resources/jdnt_company/html/company.jsp
+++ b/src/main/resources/jdnt_company/html/company.jsp
@@ -24,7 +24,8 @@
 <jcr:nodeProperty node="${currentNode}" name="industryCat" var="category"/>
 <jcr:nodeProperty node="${currentNode}" name="thumbnail" var="thumb"/>
 <c:if test="${not empty thumb}">
-    <template:module path="${thumb.node.path}" view="hidden.contentURL" editable="false" var="thumbURL"/>
+    <template:addCacheDependency node="${thumb.node}"/>
+    <c:url var="thumbURL" value="${thumb.node.url}" context="/"/>
 </c:if>
 <%--Set variable for company descriptions and remove HTML tags--%>
 <c:set var="description" value="${functions:removeHtmlTags(currentNode.properties.headline.string)}"/>

--- a/src/main/resources/jdnt_company/html/company.owl.jsp
+++ b/src/main/resources/jdnt_company/html/company.owl.jsp
@@ -20,7 +20,8 @@
 
 <%-- get the imageURL to display --%>
 <c:if test="${not empty currentNode.properties['thumbnail'].node}">
-    <template:module path="${currentNode.properties.thumbnail.node.path}" view="hidden.contentURL" editable="false" var="imageUrl"/>
+    <template:addCacheDependency node="${currentNode.properties.thumbnail.node}"/>
+    <c:url var="imageUrl" value="${currentNode.properties.thumbnail.node.url}" context="/"/>
 </c:if>
 
 <c:url var="compUrl" value="${currentNode.url}" context="/"/>

--- a/src/main/resources/jdnt_highlight/html/highlight.cards-card.jsp
+++ b/src/main/resources/jdnt_highlight/html/highlight.cards-card.jsp
@@ -49,7 +49,8 @@ and not empty currentNode.properties['internalLink'].node}">
         </div>
         <%-- only display the read more text if a link has been provided --%>
         <c:if test="${not empty linkNode}">
-            <a class="btn-more hover-effect" href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false"/>" alt="${title}">
+            <template:addCacheDependency node="${linkNode}"/>
+            <a class="btn-more hover-effect" href="<c:url value="${linkNode.url}" context="/"/>" alt="${title}">
                 <c:choose>
                     <c:when test="${jcr:isNodeType(currentNode, 'jdmix:buttonText')}">
                         <template:include view="hidden.buttonText"/>
@@ -65,7 +66,8 @@ and not empty currentNode.properties['internalLink'].node}">
     <div class="caption">
         <c:choose>
             <c:when test="${not empty linkNode}">
-                <h3><a class="hover-effect" href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false"/>">${title}</a></h3>
+                <template:addCacheDependency node="${linkNode}"/>
+                <h3><a class="hover-effect" href="<c:url value="${linkNode.url}" context="/"/>">${title}</a></h3>
             </c:when>
             <c:otherwise>
                 <h3>${title}</h3>

--- a/src/main/resources/jdnt_highlight/html/highlight.cards-overlay.jsp
+++ b/src/main/resources/jdnt_highlight/html/highlight.cards-overlay.jsp
@@ -43,7 +43,8 @@
 <c:if test="${jcr:isNodeType(currentNode, 'jdmix:hasLink') and not empty currentNode.properties['internalLink']
 and not empty currentNode.properties['internalLink'].node}">
     <c:set var="linkNode" value="${currentNode.properties['internalLink'].node}" />
-    <template:module node="${linkNode}" view="hidden.contentURL" editable="false" var="linkUrl"/>
+    <template:addCacheDependency node="${linkNode}"/>
+    <c:url var="linkUrl" value="${linkNode.url}" context="/"/>
 </c:if>
 
 

--- a/src/main/resources/jdnt_highlight/html/highlight.cards-tile.jsp
+++ b/src/main/resources/jdnt_highlight/html/highlight.cards-tile.jsp
@@ -40,7 +40,8 @@ and not empty currentNode.properties['internalLink'].node}">
 
 <div class="thumbnail-img ">
     <c:if test="${not empty linkNode}">
-        <a href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false"/>" alt="${title}">
+        <template:addCacheDependency node="${linkNode}"/>
+        <a href="<c:url value="${linkNode.url}" context="/"/>" alt="${title}">
     </c:if>
             <img class="img-responsive" src="${imageUrl}" alt="">
         <%-- only display the read more text if a link has been provided --%>

--- a/src/main/resources/jdnt_highlight/html/highlight.hidden.cards-flip.jsp
+++ b/src/main/resources/jdnt_highlight/html/highlight.hidden.cards-flip.jsp
@@ -53,7 +53,8 @@ and not empty currentNode.properties['internalLink'].node}">
             <div class="caption">
                 <c:choose>
                     <c:when test="${not empty linkNode}">
-                        <h3><a class="hover-effect" href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false"/>">${fn:replace(title, fn:substring(title, 30, fn:length(title)), ' ...')}</a></h3>
+                        <template:addCacheDependency node="${linkNode}"/>
+                        <h3><a class="hover-effect" href="<c:url value="${linkNode.url}" context="/"/>">${fn:replace(title, fn:substring(title, 30, fn:length(title)), ' ...')}</a></h3>
                     </c:when>
                     <c:otherwise>
                         <h3>${fn:replace(title, fn:substring(title, 30, fn:length(title)), ' ...')}</h3>
@@ -62,7 +63,8 @@ and not empty currentNode.properties['internalLink'].node}">
                 <p>${fn:replace(description, fn:substring(description, 100, fn:length(description)), ' ...')}</p>
                 <%-- only display the read more text if a link has been provided --%>
                 <c:if test="${not empty linkNode}">
-                    <a class="btn-more-2 hover-effect" href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false"/>" alt="${title}">
+                    <template:addCacheDependency node="${linkNode}"/>
+                    <a class="btn-more-2 hover-effect" href="<c:url value="${linkNode.url}" context="/"/>" alt="${title}">
                         <c:choose>
                             <c:when test="${jcr:isNodeType(currentNode, 'jdmix:buttonText')}">
                                 <template:include view="hidden.buttonText"/>

--- a/src/main/resources/jdnt_highlight/html/highlight.imgView.jsp
+++ b/src/main/resources/jdnt_highlight/html/highlight.imgView.jsp
@@ -45,7 +45,8 @@ and not empty currentNode.properties['internalLink'].node}">
         </div>
         <%-- only display the read more text if a link has been provided --%>
         <c:if test="${not empty linkNode}">
-            <a class="btn-more hover-effect" href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false"/>" alt="${title}">
+            <template:addCacheDependency node="${linkNode}"/>
+            <a class="btn-more hover-effect" href="<c:url value="${linkNode.url}" context="/"/>" alt="${title}">
                 <c:choose>
                     <c:when test="${jcr:isNodeType(currentNode, 'jdmix:buttonText')}">
                         <template:include view="hidden.buttonText"/>
@@ -60,7 +61,8 @@ and not empty currentNode.properties['internalLink'].node}">
     <div class="caption">
         <c:choose>
             <c:when test="${not empty linkNode}">
-                <h3><a class="hover-effect" href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false"/>">${title}</a></h3>
+                <template:addCacheDependency node="${linkNode}"/>
+                <h3><a class="hover-effect" href="<c:url value="${linkNode.url}" context="/"/>">${title}</a></h3>
             </c:when>
             <c:otherwise>
                 <h3><a class="hover-effect" href="#">${title}</a></h3>

--- a/src/main/resources/jdnt_highlight/html/highlight.jsp
+++ b/src/main/resources/jdnt_highlight/html/highlight.jsp
@@ -30,7 +30,8 @@ and not empty currentNode.properties['internalLink'].node}">
     <c:choose>
         <%-- if there is a link display, make the icon clickable --%>
         <c:when test="${not empty linkNode}">
-            <a href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false"/>"><i class="fa ${icon} service-icon"></i></a>
+            <template:addCacheDependency node="${linkNode}"/>
+            <a href="<c:url value="${linkNode.url}" context="/"/>"><i class="fa ${icon} service-icon"></i></a>
         </c:when>
         <c:otherwise><i class="fa ${icon} service-icon"></i></c:otherwise>
     </c:choose>
@@ -40,7 +41,8 @@ and not empty currentNode.properties['internalLink'].node}">
         <p>${description}</p>
         <%-- display a read more text link if a link has been provided --%>
         <c:if test="${not empty linkNode}">
-            <a href="<template:module node="${linkNode}" view="hidden.contentURL" editable="false"/>" alt="${title}">
+            <template:addCacheDependency node="${linkNode}"/>
+            <a href="<c:url value="${linkNode.url}" context="/"/>" alt="${title}">
                 <c:choose>
                     <c:when test="${jcr:isNodeType(currentNode, 'jdmix:buttonText')}">
                         <template:include view="hidden.buttonText"/>

--- a/src/main/resources/jdnt_mediaGalleryExternalVideo/html/mediaGalleryExternalVideo.jsp
+++ b/src/main/resources/jdnt_mediaGalleryExternalVideo/html/mediaGalleryExternalVideo.jsp
@@ -13,7 +13,8 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 
 <c:set var="image" value="${currentNode.properties['videoPoster'].node}"/>
-<template:module path='${image.path}' editable='false' view='hidden.contentURL' var="imageUrl"/>
+<template:addCacheDependency node="${image}"/>
+<c:url var="imageUrl" value="${image.url}" context="/"/>
 <template:module path='${image.path}' editable='false' view='hidden.imageSize' var="imageSize"/>
 
 <c:set var="caption" value="${currentNode.properties['jcr:title'].string}"/>

--- a/src/main/resources/jdnt_mediaGalleryImg/html/mediaGalleryImg.jsp
+++ b/src/main/resources/jdnt_mediaGalleryImg/html/mediaGalleryImg.jsp
@@ -13,7 +13,8 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 
 <c:set var="image" value="${currentNode.properties['image'].node}"/>
-<template:module path='${image.path}' editable='false' view='hidden.contentURL' var="imageUrl"/>
+<template:addCacheDependency node="${image}"/>
+<c:url var="imageUrl" value="${image.url}" context="/"/>
 <template:module path='${image.path}' editable='false' view='hidden.imageSize' var="imageSize"/>
 
 <c:set var="caption" value="${currentNode.properties['jcr:title'].string}"/>

--- a/src/main/resources/jdnt_mediaGalleryInternalVideo/html/mediaGalleryInternalVideo.jsp
+++ b/src/main/resources/jdnt_mediaGalleryInternalVideo/html/mediaGalleryInternalVideo.jsp
@@ -13,12 +13,14 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 
 <c:set var="image" value="${currentNode.properties['videoPoster'].node}"/>
-<template:module path='${image.path}' editable='false' view='hidden.contentURL' var="imageUrl"/>
+<template:addCacheDependency node="${image}"/>
+<c:url var="imageUrl" value="${image.url}" context="/"/>
 
 <c:set var="caption" value="${currentNode.properties['jcr:title'].string}"/>
 
 <c:set var="itemWidth" value="${currentNode.parent.properties['itemWidth'].string}"/>
-<template:module path='${currentNode.properties.video.node.path}' editable='false' view='hidden.contentURL' var="videoURL"/>
+<template:addCacheDependency node="${currentNode.properties.video.node}"/>
+<c:url var="videoURL" value="${currentNode.properties.video.node.url}" context="/"/>
 <galleryfigure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject" >
 <c:choose>
     <c:when test="${renderContext.editMode}">

--- a/src/main/resources/jdnt_parallaxSliderItem/html/parallaxSliderItem.jsp
+++ b/src/main/resources/jdnt_parallaxSliderItem/html/parallaxSliderItem.jsp
@@ -21,7 +21,8 @@
 
 <c:set var="backgroundImg" value="${currentNode.properties['backgroundImg'].node}"/>
 <c:if test="${not empty backgroundImg}">
-    <template:module path='${backgroundImg.path}' editable='false' view='hidden.contentURL' var="backgroundImgUrl"/>
+    <template:addCacheDependency node="${backgroundImg}"/>
+    <c:url var="backgroundImgUrl" value="${backgroundImg.url}" context="/"/>
 </c:if>
 <c:set var="pause" value="${currentNode.properties['pause'].boolean}"/>
 <c:set var="width" value="${currentNode.properties['width'].string}"/>

--- a/src/main/resources/jdnt_sliderPanel/html/sliderPanel.edit.collapsible.jsp
+++ b/src/main/resources/jdnt_sliderPanel/html/sliderPanel.edit.collapsible.jsp
@@ -75,7 +75,8 @@
         </c:if>
 
         <c:if test="${not empty link}">
-            <a class="but-layer-editslider" href="<template:module node="${link}" view="hidden.contentURL" editable="false"/>" alt="${title}">${linkText}</a>
+            <template:addCacheDependency node="${link}"/>
+            <a class="but-layer-editslider" href="<c:url value="${link.url}" context="/"/>" alt="${title}">${linkText}</a>
         </c:if>
     </div>
     <%-- second image if exists --%>

--- a/src/main/resources/jdnt_sliderPanel/html/sliderPanel.hidden.content.jsp
+++ b/src/main/resources/jdnt_sliderPanel/html/sliderPanel.hidden.content.jsp
@@ -41,7 +41,8 @@
         <c:url var="backgroundUrl" value="${url.currentModule}/img/background.jpg"/>
     </c:when>
     <c:otherwise>
-        <template:module path='${background.path}' editable='false' view='hidden.contentURL' var="backgroundUrl"/>
+        <template:addCacheDependency node="${background}"/>
+        <c:url var="backgroundUrl" value="${background.url}" context="/" />
     </c:otherwise>
 </c:choose>
 
@@ -63,7 +64,8 @@
 
     <%-- if a small photo was provided display it --%>
     <c:if test="${not empty image}">
-        <template:module path='${image.path}' editable='false' view='hidden.contentURL' var="imageUrl"/>
+        <template:addCacheDependency node="${image}"/>
+        <c:url var="imageUrl" value="${image.url}" context="/"/>
         <div class="ms-layer sidePanelPhoto"
              style="left: ${photoLayout};">
             <img src="${imageUrl}" alt=""/>
@@ -103,7 +105,8 @@
 
     <%-- if a link has been provided display it as a button --%>
     <c:if test="${not empty link}">
-        <a class="ms-layer btn-u top390" style="left:${textLayout}" href="<template:module node="${link}" view="hidden.contentURL"/>"
+        <template:addCacheDependency node="${link}"/>
+        <a class="ms-layer btn-u top390" style="left:${textLayout}" href="<c:url value="${link.url}" context="/"/>"
            data-effect="bottom(40)"
            data-duration="2000"
            data-delay="1300"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/TECH-2055

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Replace the usages of `<template:module>` used as HTML tags attributes, as it prevents the `HtmlTagAttributeVisitor` visitors (in particular the `UrlRewriteVisitor`) to be called for those tags, causing issues with _Cloudimage_ that relies on URL rewrite rules.

